### PR TITLE
feat: post slugs

### DIFF
--- a/migrations/1784050000000_post_add-slug.ts
+++ b/migrations/1784050000000_post_add-slug.ts
@@ -1,0 +1,12 @@
+import type { Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+	await db.schema.alterTable('post').addColumn('slug', 'varchar(512)').execute();
+
+	await db.schema.createIndex('post_slug_unique').on('post').column('slug').unique().execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await db.schema.dropIndex('post_slug_unique').execute();
+	await db.schema.alterTable('post').dropColumn('slug').execute();
+}

--- a/src/post/dto/base-post.dto.ts
+++ b/src/post/dto/base-post.dto.ts
@@ -13,6 +13,11 @@ export class BasePostDto {
 	@IsNotEmpty()
 	title: string;
 
+	@ApiPropertyOptional()
+	@IsString()
+	@IsOptional()
+	slug?: string;
+
 	@ApiProperty()
 	@IsUUID()
 	@IsNotEmpty()

--- a/src/post/dto/create-post.dto.ts
+++ b/src/post/dto/create-post.dto.ts
@@ -1,4 +1,10 @@
-import { OmitType } from '@nestjs/swagger';
+import { ApiPropertyOptional, OmitType } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
 import { BasePostDto } from './base-post.dto';
 
-export class CreatePostDto extends OmitType(BasePostDto, ['id', 'markdown_content_id', 'created_at'] as const) {}
+export class CreatePostDto extends OmitType(BasePostDto, ['id', 'slug', 'markdown_content_id', 'created_at'] as const) {
+	@ApiPropertyOptional({ description: 'Generate a permanent slug from the title' })
+	@IsBoolean()
+	@IsOptional()
+	generate_slug?: boolean;
+}

--- a/src/post/dto/update-post.dto.ts
+++ b/src/post/dto/update-post.dto.ts
@@ -1,7 +1,13 @@
-import { IntersectionType, OmitType, PartialType, PickType } from '@nestjs/swagger';
+import { ApiPropertyOptional, IntersectionType, OmitType, PartialType, PickType } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
 import { BasePostDto } from './base-post.dto';
 
 export class UpdatePostDto extends IntersectionType(
 	PickType(BasePostDto, ['id'] as const),
-	PartialType(OmitType(BasePostDto, ['id', 'markdown_content_id', 'created_at'] as const)),
-) {}
+	PartialType(OmitType(BasePostDto, ['id', 'slug', 'markdown_content_id', 'created_at'] as const)),
+) {
+	@ApiPropertyOptional({ description: 'Generate a permanent slug when the post does not have one yet' })
+	@IsBoolean()
+	@IsOptional()
+	generate_slug?: boolean;
+}

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -5,6 +5,7 @@ import { Timestamp } from '../common/kysely-types/timestamp';
 export interface PostTable {
 	id: Generated<string>;
 	title: string;
+	slug: string | null;
 	markdown_content_id: string;
 	video_id: string | null;
 	created_at: Generated<Timestamp>;

--- a/src/post/post.repository.ts
+++ b/src/post/post.repository.ts
@@ -51,6 +51,10 @@ export class PostRepository {
 		return await this.connection.selectFrom('post').selectAll().where('id', '=', id).limit(1).executeTakeFirst();
 	}
 
+	async findBySlug(slug: string): Promise<Post | undefined> {
+		return await this.connection.selectFrom('post').selectAll().where('slug', '=', slug).limit(1).executeTakeFirst();
+	}
+
 	async findByIdWithContent(id: string): Promise<PostWithContent | undefined> {
 		const row = await this.connection
 			.selectFrom('post')
@@ -58,6 +62,28 @@ export class PostRepository {
 			.selectAll('post')
 			.select(eb => [eb.ref('markdown_content.content_text').as('markdown_content')])
 			.where('post.id', '=', id)
+			.limit(1)
+			.executeTakeFirst();
+
+		if (!row) {
+			return undefined;
+		}
+
+		const { markdown_content, ...post } = row;
+
+		return {
+			...post,
+			markdown_content: markdown_content ?? '',
+		};
+	}
+
+	async findBySlugWithContent(slug: string): Promise<PostWithContent | undefined> {
+		const row = await this.connection
+			.selectFrom('post')
+			.innerJoin('markdown_content', 'markdown_content.id', 'post.markdown_content_id')
+			.selectAll('post')
+			.select(eb => [eb.ref('markdown_content.content_text').as('markdown_content')])
+			.where('post.slug', '=', slug)
 			.limit(1)
 			.executeTakeFirst();
 

--- a/src/post/usecases/create-post/create-post.controller.e2e-spec.ts
+++ b/src/post/usecases/create-post/create-post.controller.e2e-spec.ts
@@ -119,6 +119,63 @@ describe('[E2E] Create post usecase', () => {
 		expect(res.body.title).to.equal(dto.title);
 		expect(res.body.markdown_content).to.equal(dto.markdown_content);
 		expect(res.body.video_id).to.equal(undefined);
+		expect(res.body.slug).to.equal(undefined);
 		expect(res.body.markdown_content_id).to.be.a('string');
+	});
+
+	it('Admin can generate a deterministic slug from Russian letters and numbers', async () => {
+		const admin = await createTestAdmin(userUtilRepository);
+		const dto = createTestPostDto({
+			title: 'Урок 12: Работа с API',
+			generate_slug: true,
+		});
+
+		const res = await postTestSdk.createPost({
+			params: dto,
+			userMeta: { userId: admin.id, isAuth: true, isWrongAccessJwt: false },
+		});
+
+		expect(res.status).to.equal(HttpStatus.CREATED);
+		if (res.status !== HttpStatus.CREATED) throw new Error('Failed to create post');
+		expect(res.body.slug).to.equal('urok-12-rabota-s-api');
+	});
+
+	for (const { title, caseName } of [
+		{ title: '🎉 !!!', caseName: 'an empty normalized slug' },
+		{ title: 'New', caseName: 'the reserved "new" slug' },
+		{ title: '550e8400-e29b-41d4-a716-446655440000', caseName: 'a UUID-like slug' },
+	]) {
+		it(`Rejects slug generation for ${caseName}`, async () => {
+			const admin = await createTestAdmin(userUtilRepository);
+
+			const res = await postTestSdk.createPost({
+				params: createTestPostDto({ title, generate_slug: true }),
+				userMeta: { userId: admin.id, isAuth: true, isWrongAccessJwt: false },
+			});
+
+			expect(res.status).to.equal(HttpStatus.BAD_REQUEST);
+			if (res.status !== HttpStatus.BAD_REQUEST) throw new Error('Expected slug validation to fail');
+			expect(res.body.description).to.equal('Невозможно создать постоянную ссылку из этого названия');
+		});
+	}
+
+	it('Rejects a duplicate normalized slug with a distinct message', async () => {
+		const admin = await createTestAdmin(userUtilRepository);
+		const userMeta = { userId: admin.id, isAuth: true as const, isWrongAccessJwt: false };
+
+		const first = await postTestSdk.createPost({
+			params: createTestPostDto({ title: 'Новый пост 12', generate_slug: true }),
+			userMeta,
+		});
+		expect(first.status).to.equal(HttpStatus.CREATED);
+
+		const duplicate = await postTestSdk.createPost({
+			params: createTestPostDto({ title: 'Новый, пост 12!', generate_slug: true }),
+			userMeta,
+		});
+
+		expect(duplicate.status).to.equal(HttpStatus.CONFLICT);
+		if (duplicate.status !== HttpStatus.CONFLICT) throw new Error('Expected a slug conflict');
+		expect(duplicate.body.description).to.equal('Пост с такой постоянной ссылкой уже существует');
 	});
 });

--- a/src/post/usecases/create-post/create-post.usecase.ts
+++ b/src/post/usecases/create-post/create-post.usecase.ts
@@ -23,12 +23,11 @@ export class CreatePostUsecase implements UsecaseInterface {
 
 		const markdown = await this.markdownContentService.uploadMarkdownContent(markdown_content);
 
-		const post = await this.postRepository
-			.save({
-				...postData,
-				slug: slug ?? null,
-				markdown_content_id: markdown.id,
-			});
+		const post = await this.postRepository.save({
+			...postData,
+			slug: slug ?? null,
+			markdown_content_id: markdown.id,
+		});
 
 		return {
 			...post,

--- a/src/post/usecases/create-post/create-post.usecase.ts
+++ b/src/post/usecases/create-post/create-post.usecase.ts
@@ -4,6 +4,7 @@ import { MarkdownContentService } from '../../../markdown-content/services/markd
 import { PostRepository } from '../../post.repository';
 import { PostResponseDto } from '../../dto/base-post.dto';
 import { CreatePostDto } from '../../dto/create-post.dto';
+import { generateValidPostSlug, throwDuplicatePostSlug } from '../../utils/post-slug.util';
 
 @Injectable()
 export class CreatePostUsecase implements UsecaseInterface {
@@ -13,17 +14,25 @@ export class CreatePostUsecase implements UsecaseInterface {
 	) {}
 
 	async execute(dto: CreatePostDto): Promise<PostResponseDto> {
-		const { markdown_content, ...postData } = dto;
+		const { markdown_content, generate_slug, ...postData } = dto;
+		const slug = generate_slug ? generateValidPostSlug(dto.title) : undefined;
+
+		if (slug && (await this.postRepository.findBySlug(slug))) {
+			throwDuplicatePostSlug();
+		}
 
 		const markdown = await this.markdownContentService.uploadMarkdownContent(markdown_content);
 
-		const post = await this.postRepository.save({
-			...postData,
-			markdown_content_id: markdown.id,
-		});
+		const post = await this.postRepository
+			.save({
+				...postData,
+				slug: slug ?? null,
+				markdown_content_id: markdown.id,
+			});
 
 		return {
 			...post,
+			slug: post.slug ?? undefined,
 			video_id: post.video_id ?? undefined,
 			markdown_content: markdown.content_text,
 			locked_preview: undefined,

--- a/src/post/usecases/delete-post/delete-post.usecase.ts
+++ b/src/post/usecases/delete-post/delete-post.usecase.ts
@@ -27,6 +27,7 @@ export class DeletePostUsecase implements UsecaseInterface {
 
 		return {
 			...deleted,
+			slug: deleted.slug ?? undefined,
 			video_id: deleted.video_id ?? undefined,
 			markdown_content: markdown.content_text,
 			locked_preview: undefined,

--- a/src/post/usecases/get-post/get-post.controller.e2e-spec.ts
+++ b/src/post/usecases/get-post/get-post.controller.e2e-spec.ts
@@ -130,6 +130,25 @@ describe('[E2E] Get post by id usecase', () => {
 		expect(res.body.markdown_content).to.equal(created.markdown.content_text);
 	});
 
+	it('Authenticated users can get a slug-enabled post by UUID or slug', async () => {
+		const user = await createTestUser(userUtilRepository);
+		const created = await createTestPost(postUtilRepository, markdownUtilRepository, {
+			post: { title: 'Пост со ссылкой', slug: 'post-so-ssylkoy' },
+		});
+
+		for (const identifier of [created.post.id, created.post.slug!]) {
+			const res = await postTestSdk.getPostById({
+				params: { id: identifier },
+				userMeta: { userId: user.id, isAuth: true, isWrongAccessJwt: false },
+			});
+
+			expect(res.status).to.equal(HttpStatus.OK);
+			if (res.status !== HttpStatus.OK) throw new Error('Request failed');
+			expect(res.body.id).to.equal(created.post.id);
+			expect(res.body.slug).to.equal(created.post.slug);
+		}
+	});
+
 	describe('Subscriber access', () => {
 		let subscriber: TestSubscriber;
 		let otherTierId: string;

--- a/src/post/usecases/get-post/get-post.controller.ts
+++ b/src/post/usecases/get-post/get-post.controller.ts
@@ -18,10 +18,10 @@ export class GetPostController {
 	})
 	@Get(':id')
 	@HttpCode(HttpStatus.OK)
-	@ApiParam({ name: 'id', description: 'ID поста', type: String })
-	async get(@Param('id') id: string, @Req() req: RequestWithUser): Promise<PostResponseDto> {
+	@ApiParam({ name: 'id', description: 'ID или постоянная ссылка поста', type: String })
+	async get(@Param('id') identifier: string, @Req() req: RequestWithUser): Promise<PostResponseDto> {
 		const user = req['user'];
 
-		return this.getPostUsecase.execute({ id, user });
+		return this.getPostUsecase.execute({ identifier, user });
 	}
 }

--- a/src/post/usecases/get-post/get-post.usecase.ts
+++ b/src/post/usecases/get-post/get-post.usecase.ts
@@ -4,13 +4,22 @@ import { UserWithSubscriptionTier } from '../../../user/user.entity';
 import { PostResponseDto } from '../../dto/base-post.dto';
 import { PostRepository } from '../../post.repository';
 import { PostWithContent } from '../../post.entity';
+import { isUuid } from '../../utils/post-slug.util';
 
 @Injectable()
 export class GetPostUsecase implements UsecaseInterface {
 	constructor(private readonly postRepository: PostRepository) {}
 
-	async execute({ id, user }: { id: string; user: UserWithSubscriptionTier }): Promise<PostResponseDto> {
-		const post = await this.postRepository.findByIdWithContent(id);
+	async execute({
+		identifier,
+		user,
+	}: {
+		identifier: string;
+		user: UserWithSubscriptionTier;
+	}): Promise<PostResponseDto> {
+		const post = isUuid(identifier)
+			? await this.postRepository.findByIdWithContent(identifier)
+			: await this.postRepository.findBySlugWithContent(identifier);
 
 		if (!post) {
 			throw new NotFoundException('Пост не найден');
@@ -22,6 +31,7 @@ export class GetPostUsecase implements UsecaseInterface {
 
 		const base: PostResponseDto = {
 			...post,
+			slug: post.slug ?? undefined,
 			video_id: post.video_id ?? undefined,
 			markdown_content: post.markdown_content,
 			locked_preview: undefined,

--- a/src/post/usecases/list-posts/list-posts.usecase.ts
+++ b/src/post/usecases/list-posts/list-posts.usecase.ts
@@ -41,6 +41,7 @@ export class ListPostsUsecase implements UsecaseInterface {
 
 			const base: PostResponseDto = {
 				...post,
+				slug: post.slug ?? undefined,
 				video_id: post.video_id ?? undefined,
 				locked_preview: undefined,
 				minimal_tier_id: minimumTier?.id,

--- a/src/post/usecases/update-post/update-post.controller.e2e-spec.ts
+++ b/src/post/usecases/update-post/update-post.controller.e2e-spec.ts
@@ -164,4 +164,58 @@ describe('[E2E] Update post usecase', () => {
 		expect(res.body.markdown_content).to.equal('# Updated post content');
 		expect(res.body.markdown_content_id).to.equal(markdown.id);
 	});
+
+	it('Admin can generate a slug for an existing post', async () => {
+		const admin = await createTestAdmin(userUtilRepository);
+		const { post } = await createTestPost(postUtilRepository, markdownUtilRepository, {
+			post: { title: 'Старое название' },
+		});
+
+		const res = await postTestSdk.updatePost({
+			params: {
+				id: post.id,
+				title: 'Пост номер 42',
+				generate_slug: true,
+			},
+			userMeta: { userId: admin.id, isAuth: true, isWrongAccessJwt: false },
+		});
+
+		expect(res.status).to.equal(HttpStatus.OK);
+		if (res.status !== HttpStatus.OK) throw new Error('Failed to update post');
+		expect(res.body.slug).to.equal('post-nomer-42');
+	});
+
+	it('Keeps an existing slug frozen when the title changes', async () => {
+		const admin = await createTestAdmin(userUtilRepository);
+		const { post } = await createTestPost(postUtilRepository, markdownUtilRepository, {
+			post: { title: 'Первое название', slug: 'pervoe-nazvanie' },
+		});
+
+		const res = await postTestSdk.updatePost({
+			params: {
+				id: post.id,
+				title: 'Совсем другое название',
+				generate_slug: true,
+			},
+			userMeta: { userId: admin.id, isAuth: true, isWrongAccessJwt: false },
+		});
+
+		expect(res.status).to.equal(HttpStatus.OK);
+		if (res.status !== HttpStatus.OK) throw new Error('Failed to update post');
+		expect(res.body.slug).to.equal('pervoe-nazvanie');
+	});
+
+	it('Rejects an invalid slug when enabling a permanent link on an existing post', async () => {
+		const admin = await createTestAdmin(userUtilRepository);
+		const { post } = await createTestPost(postUtilRepository, markdownUtilRepository);
+
+		const res = await postTestSdk.updatePost({
+			params: { id: post.id, title: 'New', generate_slug: true },
+			userMeta: { userId: admin.id, isAuth: true, isWrongAccessJwt: false },
+		});
+
+		expect(res.status).to.equal(HttpStatus.BAD_REQUEST);
+		if (res.status !== HttpStatus.BAD_REQUEST) throw new Error('Expected slug validation to fail');
+		expect(res.body.description).to.equal('Невозможно создать постоянную ссылку из этого названия');
+	});
 });

--- a/src/post/usecases/update-post/update-post.usecase.ts
+++ b/src/post/usecases/update-post/update-post.usecase.ts
@@ -4,6 +4,7 @@ import { MarkdownContentService } from '../../../markdown-content/services/markd
 import { PostResponseDto } from '../../dto/base-post.dto';
 import { UpdatePostDto } from '../../dto/update-post.dto';
 import { PostRepository } from '../../post.repository';
+import { generateValidPostSlug, isPostSlugUniqueViolation, throwDuplicatePostSlug } from '../../utils/post-slug.util';
 
 @Injectable()
 export class UpdatePostUsecase implements UsecaseInterface {
@@ -19,16 +20,33 @@ export class UpdatePostUsecase implements UsecaseInterface {
 			throw new NotFoundException('Пост не найден');
 		}
 
-		const { id, markdown_content, ...updates } = dto;
+		const { id, markdown_content, generate_slug, ...updates } = dto;
+		let slug: string | undefined;
+
+		if (generate_slug && !existing.slug) {
+			slug = generateValidPostSlug(updates.title ?? existing.title);
+		}
 
 		const markdown = markdown_content
 			? await this.markdownContentService.updateMarkdownContent(existing.markdown_content_id, markdown_content)
 			: await this.markdownContentService.getMarkdownContent(existing.markdown_content_id);
 
-		const updated = await this.postRepository.update(id, updates);
+		const updated = await this.postRepository
+			.update(id, {
+				...updates,
+				...(slug ? { slug } : {}),
+			})
+			.catch(error => {
+				if (isPostSlugUniqueViolation(error)) {
+					throwDuplicatePostSlug();
+				}
+
+				throw error;
+			});
 
 		return {
 			...updated,
+			slug: updated.slug ?? undefined,
 			video_id: updated.video_id ?? undefined,
 			markdown_content: markdown.content_text,
 			locked_preview: undefined,

--- a/src/post/utils/post-slug.util.ts
+++ b/src/post/utils/post-slug.util.ts
@@ -1,0 +1,86 @@
+import { BadRequestException, ConflictException } from '@nestjs/common';
+
+const RUSSIAN_TRANSLITERATION: Readonly<Record<string, string>> = {
+	а: 'a',
+	б: 'b',
+	в: 'v',
+	г: 'g',
+	д: 'd',
+	е: 'e',
+	ё: 'yo',
+	ж: 'zh',
+	з: 'z',
+	и: 'i',
+	й: 'y',
+	к: 'k',
+	л: 'l',
+	м: 'm',
+	н: 'n',
+	о: 'o',
+	п: 'p',
+	р: 'r',
+	с: 's',
+	т: 't',
+	у: 'u',
+	ф: 'f',
+	х: 'kh',
+	ц: 'ts',
+	ч: 'ch',
+	ш: 'sh',
+	щ: 'shch',
+	ъ: '',
+	ы: 'y',
+	ь: '',
+	э: 'e',
+	ю: 'yu',
+	я: 'ya',
+};
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const RESERVED_SLUGS = new Set(['new']);
+
+export const INVALID_POST_SLUG_MESSAGE = 'Невозможно создать постоянную ссылку из этого названия';
+export const DUPLICATE_POST_SLUG_MESSAGE = 'Пост с такой постоянной ссылкой уже существует';
+
+export function generatePostSlug(title: string): string {
+	const transliterated = Array.from(
+		title.toLowerCase(),
+		character => RUSSIAN_TRANSLITERATION[character] ?? character,
+	).join('');
+
+	return transliterated
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+		.replace(/-+/g, '-');
+}
+
+export function isValidPostSlug(slug: string): boolean {
+	return slug.length > 0 && !RESERVED_SLUGS.has(slug) && !UUID_PATTERN.test(slug);
+}
+
+export function isUuid(value: string): boolean {
+	return UUID_PATTERN.test(value);
+}
+
+export function generateValidPostSlug(title: string): string {
+	const slug = generatePostSlug(title);
+
+	if (!isValidPostSlug(slug)) {
+		throw new BadRequestException(INVALID_POST_SLUG_MESSAGE);
+	}
+
+	return slug;
+}
+
+export function throwDuplicatePostSlug(): never {
+	throw new ConflictException(DUPLICATE_POST_SLUG_MESSAGE);
+}
+
+export function isPostSlugUniqueViolation(error: unknown): boolean {
+	if (!error || typeof error !== 'object') {
+		return false;
+	}
+
+	const databaseError = error as { code?: string; constraint?: string };
+	return databaseError.code === '23505' && databaseError.constraint === 'post_slug_unique';
+}

--- a/test/fixtures/post.fixture.ts
+++ b/test/fixtures/post.fixture.ts
@@ -26,6 +26,7 @@ export const createTestPost = async (
 	const postValues = {
 		...overrides.post,
 		title: overrides.post?.title ?? randomWord(),
+		slug: overrides.post?.slug ?? null,
 		markdown_content_id: overrides.post?.markdown_content_id ?? markdown.id,
 		video_id: overrides.post?.video_id ?? null,
 	};


### PR DESCRIPTION
## Core ideas
- Добавил уникальные слаги для постов, они живут отдельно от айди и генерятся из названия. Для предыдущих постов нет бэкфилла слагов
- При создании или редактировании поста админ нажимает кнопку "создать ссылку" (create_slug параметр в POST / PATCH) и он создаётся для поста
- После создания слаг заморожен - он не поменяется даже если название поста поменяется, удалить слаг из поста так же не выйдет - такой возможности просто нет в API
- Слаг состоит из латиницы, цифр и дефисов
- Максимальная длина 512 символов (128 длина заголовка, 128*4 - самый длинный маппинг русской кириллицы в латиницу)


## Product meaning
- Можно иметь МДшник с постоянными ссылками: например страничка home или FAQ на фронте может ссылаться на статьи
- Открывается путь к публичному шарингу постов
- Фича создана чтобы иметь одинаковые посты в стаге и проде, плюс в будущем ввести публичный шаринг постов в целях пиара

## Changes
- CRUD'ы вокруг постов и их тесты
- Новая миграшка
